### PR TITLE
strpccmd() fix

### DIFF
--- a/src/org/tn5250j/framework/tn5250/tnvt.java
+++ b/src/org/tn5250j/framework/tn5250/tnvt.java
@@ -868,13 +868,15 @@ public final class tnvt implements Runnable {
 		try
 		{
 			int str = 11;
+			int offset = str+1;
+			int limit = 123; //TODO 1023 from V7R2
 			char c;
 			ScreenPlanes planes = screen52.getPlanes();
 			c = planes.getChar(str);
 			boolean waitFor = !(c == 'a');
 
 			StringBuilder command = new StringBuilder();
-			for (int i = str+1; i < 132; i++)
+			for (int i = offset; i < offset + limit; i++)
 			{
 				c = planes.getChar(i);
 				if (Character.isISOControl(c))


### PR DESCRIPTION
Like the issue: https://github.com/tn5250j/tn5250j/issues/4

The length limit for the PCCMD parameter of STRPCCMD is 123 chars, but it was truncated at 120.

In the new version of the OS (V7R2) the new limit is 1023, so I defined a var "limit" to hold the value according to the version. For now is fixed at 123, can be the  OS version retrieved in some way?

