### PR TITLE
there is a space in the shebang line of the *nix executable

### DIFF
--- a/installer/bin/tn5250j
+++ b/installer/bin/tn5250j
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 # Runs the tn5250j 5250 java emulator
 


### PR DESCRIPTION
space in the top line of the script causes the process to fail