### PR TITLE
Fix for screens transmitted over multiple packets

### DIFF
--- a/src/org/tn5250j/framework/tn5250/tnvt.java
+++ b/src/org/tn5250j/framework/tn5250/tnvt.java
@@ -1984,7 +1984,7 @@ public final class tnvt implements Runnable {
 			bk.getNextByte(); // reserved
 			bk.getNextByte(); // resequence fields
 
-			screen52.clearTable();
+			//screen52.clearTable();
 
 			// well that is the first time I have seen this. This fixes a
 			// problem


### PR DESCRIPTION
Some screens are transmitted over multiple packets. In particular more
than one writeToDisplay commands to build up a full screen. Right now
processSOH() calls clearTable() every time, even if the screen isn't
cleared. This resets the fields, which means any input fields from the
earlier packet are no longer seen as input fields. Any input to these
fields results in a "Cancel Invite Operation" being sent to the host
which responds with "Cursor in protected area of display."

By simply commenting out this call to clearTable() and relying on the
clearTable() call from clearAll() we avoid this problem, without
breaking rendering or other field functions.

This hasn't been heavily tested.