### PR TITLE
travis for old java versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ script:
 
 jdk:
   - oraclejdk8
-  - oraclejdk7
+  - openjdk7
   - openjdk6

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: java
 
+addons:
+  apt:
+    packages:
+      - openjdk-6-jdk
+
 script:
   - ant all
 


### PR DESCRIPTION
Change to openjdk7 for Java 7 builds as of changes in travis environment.

See: https://github.com/travis-ci/travis-ci/issues/7884