### PR TITLE
Fix syntax for installer shortcuts

### DIFF
--- a/installer/installShortcutSpec.xml
+++ b/installer/installShortcutSpec.xml
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
 
-<shortcuts>
+<izpack:shortcuts version="5.0"
+                  xmlns:izpack="http://izpack.org/schema/shortcuts"
+                  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                  xsi:schemaLocation="http://izpack.org/schema/shortcuts http://izpack.org/schema/5.0/izpack-shortcuts-5.0.xsd">
 
   <skipIfNotSupported />
 
@@ -32,4 +35,4 @@
      commandLine=""
      description="tn5250j uninstaller"/>
 
-</shortcuts>
+</izpack:shortcuts>


### PR DESCRIPTION
Fix the definition of shortcuts for izpack to use the correct root node
syntax. This fixes #31